### PR TITLE
chore: remove unused parameter field

### DIFF
--- a/query_runner/src/main.rs
+++ b/query_runner/src/main.rs
@@ -31,7 +31,6 @@ struct AppState {
 #[derive(Deserialize)]
 struct ExecuteQueryRequest {
     query: String,
-    params: Option<HashMap<String, Value>>,
 }
 
 // Response model


### PR DESCRIPTION
Quells a Rust warning.