### PR TITLE
fix(api): don't expect a `.env` file when run through Docker container

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -39,6 +39,6 @@ RUN touch .env && \
     echo "DATABASE_URL=\${DATABASE_URL:-postgres://postgres:postgres@db:5432/pbtar}" > .env && \
     echo "RUST_LOG=\${RUST_LOG:-info}" >> .env
 
-EXPOSE 8080
+EXPOSE 8000
 
 CMD ["/app/lucidata-api"]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
     let database_url = env::var("DATABASE_URL")
         .expect("DATABASE_URL must be set");
     
-    tracing::info!("Connecting to database at: {}", database_url.replace(|c| c != '@' && c != ':', "*"));
+    tracing::info!("Connecting to database...");
     
     let pool = PgPoolOptions::new()
         .max_connections(5)

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -14,8 +14,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() {
-    // Load environment variables
-    dotenv().ok();
+    // Load environment variables, don't require .env file in Docker
+    let _ = dotenv();
     
     // Initialize logging
     tracing_subscriber::registry()
@@ -29,11 +29,15 @@ async fn main() {
     let database_url = env::var("DATABASE_URL")
         .expect("DATABASE_URL must be set");
     
+    tracing::info!("Connecting to database at: {}", database_url.replace(|c| c != '@' && c != ':', "*"));
+    
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(&database_url)
         .await
         .expect("Failed to create pool");
+        
+    tracing::info!("Successfully connected to database");
     
     // CORS configuration
     let cors = CorsLayer::new()


### PR DESCRIPTION
The Rust API was leveraging the `dotenv()` function to read in ENV vars from a `.env` file. This was fine for local development, and deployment using `cargo run` as the `.env` file was available in the project repo.

However, in Docker, the `.env` file is actually read in to the container, and all ENV vars are available within the container. 
Expecting a `.env` doesn't make sense since it won't be there. 

This PR fixes that.
